### PR TITLE
fix typo

### DIFF
--- a/chapter_1/common.py
+++ b/chapter_1/common.py
@@ -6,7 +6,7 @@ class Node(object):
 
     def __init__(self, val):
         self._val = val
-        self.next_node = None
+        self._next_node = None
 
     @property
     def val(self):


### PR DESCRIPTION
小试了一下，init函数中，用self.next_node，还是self._next_node，似乎对Node的行为影响没有区别。

奇怪的是，如果使用self.next_node，那初始化时，init是定义并赋None值给一个多余无用的next_node属性，还是调用了next_node的setter，给定义在setter中的self._next_node属性赋None值？

二者外部行为似乎等当，那么是先有init呢，还是先有setter property呢？
